### PR TITLE
use product landing page video in favor of install instructions

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -15,7 +15,7 @@ Design your own storefront for your GoDaddy Reseller plan and have more control 
 
 With this plugin, you have the option to easily design a site with the imported product catalog, complete with your pricing, preferred currency and language. You can update your site, themes, product description, and images, easily and painlessly as well as use key features like domain search and cart widgets!
 
-[youtube https://youtu.be/mx7sRwXh444]
+[youtube https://youtu.be/3vMnghv3XcY]
 
 **Features**
 * Easily design a site that is for desktop or mobile devices in your theme


### PR DESCRIPTION
@fjarrett @EvanHerman @bfocht 

https://wordpress.org/plugins/reseller-store/ was showing the plugin installation instructions, which are now obsolete since the plugin is now available on wordpress.org