### PR TITLE
Update admin_menu priority

### DIFF
--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -76,7 +76,7 @@ final class Setup {
 		);
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_menu', [ $this, 'page' ], 9 );
+		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX );
 		add_action( 'wp_ajax_rstore_install', [ __CLASS__, 'install' ] );
 
 	}


### PR DESCRIPTION
Update `admin_menu` priority to `PHP_INT_MAX` to avoid conflicts with other plugins that also use 9 as the priority.

Originally reported on WordPress.org:
https://wordpress.org/support/topic/not-compatible-with-caldera-forms/

Caldera Source:
https://github.com/CalderaWP/Caldera-Forms/blob/master/classes/admin.php#L109