### PR TITLE
Update admin_menu priorty

### DIFF
--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -73,8 +73,8 @@ final class Setup {
 
 		} );
 
-		add_action( 'admin_enqueue_scripts',  [ $this, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_menu',             [ $this, 'page' ], PHP_INT_MAX - 1997 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
+		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX - 100 );
 		add_action( 'wp_ajax_rstore_install', [ __CLASS__, 'install' ] );
 
 	}

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -76,7 +76,7 @@ final class Setup {
 		);
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX - 100 );
+		add_action( 'admin_menu', [ $this, 'page' ] );
 		add_action( 'wp_ajax_rstore_install', [ __CLASS__, 'install' ] );
 
 	}

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -76,7 +76,7 @@ final class Setup {
 		);
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX );
+		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX - 100 );
 		add_action( 'wp_ajax_rstore_install', [ __CLASS__, 'install' ] );
 
 	}

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -67,11 +67,13 @@ final class Setup {
 		 */
 		$this->rcc_site = (string) apply_filters( 'rstore_setup_rcc', $this->rcc_site );
 
-		add_action( 'init', function () {
+		add_action(
+			'init', function () {
 
-			self::$install_nonce = rstore_prefix( 'install-' . get_current_user_id() );
+				self::$install_nonce = rstore_prefix( 'install-' . get_current_user_id() );
 
-		} );
+			}
+		);
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
 		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX - 100 );
@@ -276,7 +278,7 @@ final class Setup {
 	 *
 	 * @param  int $pl_id (optional)
 	 *
-	 * @return true|WP_Error|void
+	 * @return true|\WP_Error|void
 	 */
 	public static function install( $pl_id = 0 ) {
 
@@ -359,15 +361,15 @@ final class Setup {
 
 		flush_rewrite_rules();
 
-		foreach ( (array) $products as $product ) {
+		foreach ( (array) $products as $productData ) {
 
-			$product = new Product( $product );
+			$product = new Product( $productData );
 
 			$result = $product->import();
 
 			if ( is_wp_error( $result ) ) {
 
-				return self::install_error( $result );
+                return self::install_error( $result );
 
 			}
 
@@ -377,7 +379,7 @@ final class Setup {
 
 		if ( ! rstore_has_products() ) {
 
-			return self::install_error(
+            return self::install_error(
 				'products_import_failure',
 				esc_html__( 'Product data could not be imported, please try again later.', 'reseller-store' )
 			);
@@ -397,19 +399,16 @@ final class Setup {
 			);
 
 		}
-
-		return true;
-
 	}
 
 	/**
 	 * Return an install error.
 	 *
-	 * @param  string|WP_Error $code
+	 * @param  string|\WP_Error $code
 	 * @param  string          $message
 	 * @param  string          $data
 	 *
-	 * @return WP_Error|void  Returns a `WP_Error`, or prints an error as JSON and dies when called during an AJAX request.
+	 * @return \WP_Error|void  Returns a `WP_Error`, or prints an error as JSON and dies when called during an AJAX request.
 	 */
 	private static function install_error( $code = '', $message = '', $data = '' ) {
 
@@ -419,7 +418,7 @@ final class Setup {
 
 		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
 
-			return ( $wp_error ) ? $wp_error : new WP_Error( $code, $message, $data );
+			return ( $wp_error ) ? $wp_error : new \WP_Error( $code, $message, $data );
 
 		}
 

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -76,7 +76,7 @@ final class Setup {
 		);
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_menu', [ $this, 'page' ], 9 );
+		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX );
 		add_action( 'wp_ajax_rstore_install', [ __CLASS__, 'install' ] );
 
 	}

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -74,7 +74,7 @@ final class Setup {
 		} );
 
 		add_action( 'admin_enqueue_scripts',  [ $this, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_menu',             [ $this, 'page' ], PHP_INT_MAX - 100 );
+		add_action( 'admin_menu',             [ $this, 'page' ], PHP_INT_MAX - 1997 );
 		add_action( 'wp_ajax_rstore_install', [ __CLASS__, 'install' ] );
 
 	}

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -67,16 +67,14 @@ final class Setup {
 		 */
 		$this->rcc_site = (string) apply_filters( 'rstore_setup_rcc', $this->rcc_site );
 
-		add_action(
-			'init', function () {
+		add_action( 'init', function () {
 
-				self::$install_nonce = rstore_prefix( 'install-' . get_current_user_id() );
+			self::$install_nonce = rstore_prefix( 'install-' . get_current_user_id() );
 
-			}
-		);
+		} );
 
-		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_menu', [ $this, 'page' ] );
+		add_action( 'admin_enqueue_scripts',  [ $this, 'admin_enqueue_scripts' ] );
+		add_action( 'admin_menu',             [ $this, 'page' ], PHP_INT_MAX - 100 );
 		add_action( 'wp_ajax_rstore_install', [ __CLASS__, 'install' ] );
 
 	}
@@ -278,7 +276,7 @@ final class Setup {
 	 *
 	 * @param  int $pl_id (optional)
 	 *
-	 * @return true|\WP_Error|void
+	 * @return true|WP_Error|void
 	 */
 	public static function install( $pl_id = 0 ) {
 
@@ -361,15 +359,15 @@ final class Setup {
 
 		flush_rewrite_rules();
 
-		foreach ( (array) $products as $productData ) {
+		foreach ( (array) $products as $product ) {
 
-			$product = new Product( $productData );
+			$product = new Product( $product );
 
 			$result = $product->import();
 
 			if ( is_wp_error( $result ) ) {
 
-                return self::install_error( $result );
+				return self::install_error( $result );
 
 			}
 
@@ -379,7 +377,7 @@ final class Setup {
 
 		if ( ! rstore_has_products() ) {
 
-            return self::install_error(
+			return self::install_error(
 				'products_import_failure',
 				esc_html__( 'Product data could not be imported, please try again later.', 'reseller-store' )
 			);
@@ -399,16 +397,19 @@ final class Setup {
 			);
 
 		}
+
+		return true;
+
 	}
 
 	/**
 	 * Return an install error.
 	 *
-	 * @param  string|\WP_Error $code
+	 * @param  string|WP_Error $code
 	 * @param  string          $message
 	 * @param  string          $data
 	 *
-	 * @return \WP_Error|void  Returns a `WP_Error`, or prints an error as JSON and dies when called during an AJAX request.
+	 * @return WP_Error|void  Returns a `WP_Error`, or prints an error as JSON and dies when called during an AJAX request.
 	 */
 	private static function install_error( $code = '', $message = '', $data = '' ) {
 
@@ -418,7 +419,7 @@ final class Setup {
 
 		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX ) {
 
-			return ( $wp_error ) ? $wp_error : new \WP_Error( $code, $message, $data );
+			return ( $wp_error ) ? $wp_error : new WP_Error( $code, $message, $data );
 
 		}
 

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -76,7 +76,7 @@ final class Setup {
 		);
 
 		add_action( 'admin_enqueue_scripts', [ $this, 'admin_enqueue_scripts' ] );
-		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX - 100 );
+		add_action( 'admin_menu', [ $this, 'page' ], PHP_INT_MAX - 1997 );
 		add_action( 'wp_ajax_rstore_install', [ __CLASS__, 'install' ] );
 
 	}


### PR DESCRIPTION
Update `admin_menu` priority to `PHP_INT_MAX` to avoid conflicts with other plugins that also use 9 as the priority.

Originally reported on WordPress.org:
https://wordpress.org/support/topic/not-compatible-with-caldera-forms/

Caldera Source:
https://github.com/CalderaWP/Caldera-Forms/blob/master/classes/admin.php#L109