### PR TITLE
Return the product widget

### DIFF
--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -180,7 +180,7 @@ final class Shortcodes {
 	 */
 	public static function is_widget( $atts = [] ) {
 
-		return isset( $atts['id'] );
+		return ( isset( $atts['id'] ) || isset( $atts['widget_id'] ) );
 
 	}
 

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -180,7 +180,7 @@ final class Shortcodes {
 	 */
 	public static function is_widget( $atts = [] ) {
 
-		return ( isset( $atts['id'] ) || isset( $atts['widget_id'] ) );
+		return isset( $atts['widget_id'] );
 
 	}
 

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -172,9 +172,11 @@ final class Shortcodes {
 	/**
 	 * Checks if the shortcode is being rendered as a widget.
 	 *
-	 * @param  array   $atts Shortcode attributes.
+	 * @since NEXT
 	 *
-	 * @return boolean       True is id key is set, else false.
+	 * @param array $atts Shortcode attributes.
+	 *
+	 * @return boolean    True is id key is set, else false.
 	 */
 	public static function is_widget( $atts = [] ) {
 

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -150,7 +150,7 @@ final class Shortcodes {
 
 		$product = new Widgets\Product();
 
-		$product->widget( $this->args, $atts );
+		return $product->widget( $this->args, $atts );
 
 	}
 

--- a/includes/class-shortcodes.php
+++ b/includes/class-shortcodes.php
@@ -120,7 +120,7 @@ final class Shortcodes {
 
 		$domain = new Widgets\Domain_Search();
 
-		$domain->widget( $this->args, $atts );
+		return $domain->widget( $this->args, $atts );
 
 	}
 
@@ -135,7 +135,7 @@ final class Shortcodes {
 
 		$cart = new Widgets\Cart();
 
-		$cart->widget( $this->args, $atts );
+		return $cart->widget( $this->args, $atts );
 
 	}
 
@@ -165,7 +165,20 @@ final class Shortcodes {
 
 		$login = new Widgets\Login();
 
-		$login->widget( $this->args, $atts );
+		return $login->widget( $this->args, $atts );
+
+	}
+
+	/**
+	 * Checks if the shortcode is being rendered as a widget.
+	 *
+	 * @param  array   $atts Shortcode attributes.
+	 *
+	 * @return boolean       True is id key is set, else false.
+	 */
+	public static function is_widget( $atts = [] ) {
+
+		return isset( $atts['id'] );
 
 	}
 

--- a/includes/widgets/class-cart.php
+++ b/includes/widgets/class-cart.php
@@ -13,6 +13,8 @@
 
 namespace Reseller_Store\Widgets;
 
+use Reseller_Store\Shortcodes;
+
 if ( ! defined( 'ABSPATH' ) ) {
 
 	// @codeCoverageIgnoreStart
@@ -74,6 +76,8 @@ final class Cart extends \WP_Widget {
 
 		}
 
+		ob_start();
+
 		echo $args['before_widget']; // xss ok.
 
 		$data = $this->get_data( $instance );
@@ -95,6 +99,17 @@ final class Cart extends \WP_Widget {
 		<?php
 
 		echo $args['after_widget']; // xss ok.
+
+		$cart_widget = ob_get_contents();
+		ob_get_clean();
+
+		if ( Shortcodes::is_widget( $args ) ) {
+
+			echo $cart_widget;
+
+		}
+
+		return $cart_widget;
 
 	}
 

--- a/includes/widgets/class-domain-search.php
+++ b/includes/widgets/class-domain-search.php
@@ -13,6 +13,8 @@
 
 namespace Reseller_Store\Widgets;
 
+use Reseller_Store\Shortcodes;
+
 if ( ! defined( 'ABSPATH' ) ) {
 
 	// @codeCoverageIgnoreStart
@@ -79,6 +81,8 @@ final class Domain_Search extends \WP_Widget {
 
 		}
 
+		ob_start();
+
 		echo $args['before_widget']; // xss ok.
 
 		if ( ! empty( $instance['title'] ) ) {
@@ -102,6 +106,17 @@ final class Domain_Search extends \WP_Widget {
 		echo apply_filters( 'rstore_domain_html', $domain_html );
 
 		echo $args['after_widget']; // xss ok.
+
+		$domain_search_widget = ob_get_contents();
+		ob_get_clean();
+
+		if ( Shortcodes::is_widget( $args ) ) {
+
+			echo $domain_search_widget;
+
+		}
+
+		return $domain_search_widget;
 
 	}
 

--- a/includes/widgets/class-login.php
+++ b/includes/widgets/class-login.php
@@ -13,6 +13,8 @@
 
 namespace Reseller_Store\Widgets;
 
+use Reseller_Store\Shortcodes;
+
 if ( ! defined( 'ABSPATH' ) ) {
 
 	// @codeCoverageIgnoreStart
@@ -79,6 +81,8 @@ final class Login extends \WP_Widget {
 
 		}
 
+		ob_start();
+
 		echo $args['before_widget']; // xss ok.
 
 		if ( ! empty( $instance['title'] ) ) {
@@ -106,6 +110,17 @@ final class Login extends \WP_Widget {
 		<?php
 
 		echo $args['after_widget']; // xss ok.
+
+		$login_widget = ob_get_contents();
+		ob_get_clean();
+
+		if ( Shortcodes::is_widget( $args ) ) {
+
+			echo $login_widget;
+
+		}
+
+		return $login_widget;
 
 	}
 

--- a/includes/widgets/class-product.php
+++ b/includes/widgets/class-product.php
@@ -65,8 +65,13 @@ final class Product extends \WP_Widget {
 		if ( null === $product || 'publish' !== $product->post_status ||
 			\Reseller_Store\Post_Type::SLUG !== $product->post_type ) {
 
-			esc_html_e( 'Post id is not valid.', 'reseller' );
-			return;
+			if ( Shortcodes::is_widget( $args ) ) {
+
+				esc_html_e( 'Post id is not valid.', 'reseller' );
+
+			}
+
+			return esc_html__( 'Post id is not valid.', 'reseller' );
 
 		}
 

--- a/includes/widgets/class-product.php
+++ b/includes/widgets/class-product.php
@@ -144,7 +144,14 @@ final class Product extends \WP_Widget {
 
 		}
 
-		echo $content;
+		// If ID key isset, this is a widget.
+		if ( isset( $args['id'] ) ) {
+
+			echo $content;
+
+		}
+
+		return $content;
 
 	}
 

--- a/includes/widgets/class-product.php
+++ b/includes/widgets/class-product.php
@@ -146,7 +146,6 @@ final class Product extends \WP_Widget {
 
 		}
 
-
 		if ( Shortcodes::is_widget( $args ) ) {
 
 			echo $content;

--- a/includes/widgets/class-product.php
+++ b/includes/widgets/class-product.php
@@ -13,6 +13,8 @@
 
 namespace Reseller_Store\Widgets;
 
+use Reseller_Store\Shortcodes;
+
 if ( ! defined( 'ABSPATH' ) ) {
 
 	// @codeCoverageIgnoreStart
@@ -144,8 +146,8 @@ final class Product extends \WP_Widget {
 
 		}
 
-		// If ID key isset, this is a widget.
-		if ( isset( $args['id'] ) ) {
+
+		if ( Shortcodes::is_widget( $args ) ) {
 
 			echo $content;
 

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -22,11 +22,11 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_domain_search_legacy() {
 
-		$content = '[rstore-domain-search]';
+		$this->assertContains(
+			do_shortcode( '[rstore-domain-search]' ),
+			'<div class="rstore-domain-search" data-plid= data-page_size="5" data-text_placeholder="Find your perfect domain name" data-text_search="Search" data-text_available="Congrats, your domain is available!" data-text_not_available="Sorry that domain is taken" data-text_cart="Continue to cart" data-text_select="Select" data-text_selected="Selected" data-text_verify="Verify">Domain Search</div>'
+		);
 
-		do_shortcode( $content );
-
-		$this->expectOutputRegex( '/<div class="rstore-domain-search" data-plid= data-page_size="5" data-text_placeholder="Find your perfect domain name" data-text_search="Search" data-text_available="Congrats, your domain is available!" data-text_not_available="Sorry that domain is taken" data-text_cart="Continue to cart" data-text_select="Select" data-text_selected="Selected" data-text_verify="Verify">Domain Search<\/div>/' );
 	}
 
 	/**
@@ -34,11 +34,11 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_domain_search() {
 
-		$content = '[rstore_domain_search]';
+		$this->assertContains(
+			do_shortcode( '[rstore_domain_search]' ),
+			'<div class="rstore-domain-search" data-plid= data-page_size="5" data-text_placeholder="Find your perfect domain name" data-text_search="Search" data-text_available="Congrats, your domain is available!" data-text_not_available="Sorry that domain is taken" data-text_cart="Continue to cart" data-text_select="Select" data-text_selected="Selected" data-text_verify="Verify">Domain Search</div>'
+		);
 
-		do_shortcode( $content );
-
-		$this->expectOutputRegex( '/<div class="rstore-domain-search" data-plid= data-page_size="5" data-text_placeholder="Find your perfect domain name" data-text_search="Search" data-text_available="Congrats, your domain is available!" data-text_not_available="Sorry that domain is taken" data-text_cart="Continue to cart" data-text_select="Select" data-text_selected="Selected" data-text_verify="Verify">Domain Search<\/div>/' );
 	}
 
 	/**
@@ -46,11 +46,11 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_view_cart() {
 
-		$content = '[rstore_cart_button]';
+		$this->assertRegExp(
+			'/<a href="https:\/\/cart\.secureserver\.net\/">\n.*View Cart \(<span class="rstore-cart-count">0<\/span>\)/',
+			do_shortcode( '[rstore_cart_button]' )
+		);
 
-		do_shortcode( $content );
-
-		$this->expectOutputRegex( '/<a href="https:\/\/cart\.secureserver\.net\/">\n.*View Cart \(<span class="rstore-cart-count">0<\/span>\)/' );
 	}
 
 	/**
@@ -58,11 +58,11 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_view_cart_with_params() {
 
-		$content = '[rstore_cart_button title="Cart" button_label="button label"]';
+		$this->assertRegExp(
+			'/<a href="https:\/\/cart\.secureserver\.net\/">\n.*button label \(<span class="rstore-cart-count">0<\/span>\)/',
+			do_shortcode( '[rstore_cart_button title="Cart" button_label="button label"]' )
+		);
 
-		do_shortcode( $content );
-
-		$this->expectOutputRegex( '/<a href="https:\/\/cart\.secureserver\.net\/">\n.*button label \(<span class="rstore-cart-count">0<\/span>\)/' );
 	}
 
 
@@ -71,11 +71,11 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_product_without_params() {
 
-		$content = '[rstore_product]';
+		$this->expectOutputRegex(
+			'/Post id is not valid\./',
+			do_shortcode( '[rstore_product]' )
+		);
 
-		do_shortcode( $content );
-
-		$this->expectOutputRegex( '/Post id is not valid\./' );
 	}
 
 	/**
@@ -83,11 +83,11 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_product_with_invalid_post_id() {
 
-		$content = '[rstore_product post_id=12]';
+		$this->expectOutputRegex(
+			'/Post id is not valid\./',
+			do_shortcode( '[rstore_product post_id=12]' )
+		);
 
-		do_shortcode( $content );
-
-		$this->expectOutputRegex( '/Post id is not valid\./' );
 	}
 
 	/**
@@ -97,11 +97,11 @@ final class TestShortcodes extends TestCase {
 
 		$post = Tests\Helper::create_product( 'Test Product' );
 
-		$content = '[rstore_product post_id=' . $post->ID . ']';
+		$this->assertRegExp(
+			'/Test Product/',
+			do_shortcode( '[rstore_product post_id=' . $post->ID . ']' )
+		);
 
-		do_shortcode( $content );
-
-		$this->expectOutputRegex( '/Test Product/' );
 	}
 
 	/**
@@ -139,9 +139,11 @@ final class TestShortcodes extends TestCase {
       redirect=1
       ]';
 
-		do_shortcode( $content );
+		$this->assertRegExp(
+			'/data-redirect="true"/',
+			do_shortcode( $content )
+		);
 
-		$this->expectOutputRegex( '/data-redirect="true"/' );
 	}
 
 	/**
@@ -156,9 +158,11 @@ final class TestShortcodes extends TestCase {
       redirect=0
       ]';
 
-		do_shortcode( $content );
+		$this->assertRegExp(
+			'/data-redirect="false"/',
+			do_shortcode( $content )
+		);
 
-		$this->expectOutputRegex( '/data-redirect="false"/' );
 	}
 
 	/**
@@ -166,17 +170,16 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_login() {
 
-		$post = Tests\Helper::create_product( 'Another Product good' );
-
 		$content = '[rstore_login
       welcome_message="aaaa"
       login_button_text="bbbb"
       logout_button_text="cccc"
       ]';
 
-		do_shortcode( $content );
-
-		$this->expectOutputRegex( '/<a class="logout-link" href="https:\/\/sso.secureserver.net\/logout\?plid=0&realm=idp&app=www" rel="nofollow">cccc<\/a>/' );
+		$this->assertRegExp(
+			'/<a class="logout-link" href="https:\/\/sso.secureserver.net\/logout\?plid=0&realm=idp&app=www" rel="nofollow">cccc<\/a>/',
+			do_shortcode( $content )
+		);
 
 	}
 

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -71,15 +71,8 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_product_without_params() {
 
-		ob_start();
-
-		echo do_shortcode( '[rstore_product]' );
-
-		$contents = ob_get_contents();
-		ob_get_clean();
-
 		$this->assertEquals(
-			$contents,
+			do_shortcode( '[rstore_product]' ),
 			'Post id is not valid.'
 		);
 
@@ -90,15 +83,8 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_product_with_invalid_post_id() {
 
-		ob_start();
-
-		echo do_shortcode( '[rstore_product post_id=12]' );
-
-		$contents = ob_get_contents();
-		ob_get_clean();
-
 		$this->assertEquals(
-			$contents,
+			do_shortcode( '[rstore_product post_id=12]' ),
 			'Post id is not valid.'
 		);
 

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -71,9 +71,16 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_product_without_params() {
 
-		$this->expectOutputRegex(
-			'/Post id is not valid\./',
-			do_shortcode( '[rstore_product]' )
+		ob_start();
+
+		echo do_shortcode( '[rstore_product]' );
+
+		$contents = ob_get_contents();
+		ob_get_clean();
+
+		$this->assertEquals(
+			$contents,
+			'Post id is not valid.'
 		);
 
 	}
@@ -83,9 +90,16 @@ final class TestShortcodes extends TestCase {
 	 */
 	function test_product_with_invalid_post_id() {
 
-		$this->expectOutputRegex(
-			'/Post id is not valid\./',
-			do_shortcode( '[rstore_product post_id=12]' )
+		ob_start();
+
+		echo do_shortcode( '[rstore_product post_id=12]' );
+
+		$contents = ob_get_contents();
+		ob_get_clean();
+
+		$this->assertEquals(
+			$contents,
+			'Post id is not valid.'
 		);
 
 	}

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -198,7 +198,7 @@ final class TestShortcodes extends TestCase {
 	function test_valid_widget() {
 
 		$this->assertTrue( Shortcodes::is_widget( [
-			'id' => 'test',
+			'widget_id' => 'widget-id-123',
 		] ) );
 
 	}

--- a/tests/test-shortcodes.php
+++ b/tests/test-shortcodes.php
@@ -183,4 +183,24 @@ final class TestShortcodes extends TestCase {
 
 	}
 
+	/**
+	 * @testdox Test invalid widget.
+	 */
+	function test_invalid_widget() {
+
+		$this->assertFalse( Shortcodes::is_widget() );
+
+	}
+
+	/**
+	 * @testdox Test valid widget.
+	 */
+	function test_valid_widget() {
+
+		$this->assertTrue( Shortcodes::is_widget( [
+			'id' => 'test',
+		] ) );
+
+	}
+
 }

--- a/tests/test-widget-cart.php
+++ b/tests/test-widget-cart.php
@@ -43,10 +43,10 @@ final class TestWidgetCart extends TestCase {
 			'after_title'   => '</h3>',
 		];
 
-		$widget->widget( $args, $instance );
-
-		// display view cart link.
-		$this->expectOutputRegex( '/<a href="https:\/\/cart.secureserver.net\/">\s+View Cart \(<span class="rstore-cart-count">0<\/span>\)\s+<\/a>/' );
+		$this->assertRegExp(
+			'/<a href="https:\/\/cart.secureserver.net\/">\s+View Cart \(<span class="rstore-cart-count">0<\/span>\)\s+<\/a>/',
+			$widget->widget( $args, $instance )
+		);
 
 	}
 
@@ -125,10 +125,10 @@ final class TestWidgetCart extends TestCase {
 			'after_title'   => '</h3>',
 		];
 
-		$widget->widget( $args, $instance );
-
-		// display main div tag.
-		$this->expectOutputRegex( '/<div class="before_widget cart">/' );
+		$this->assertRegExp(
+			'/<div class="before_widget cart">/',
+			$widget->widget( $args, $instance )
+		);
 
 	}
 

--- a/tests/test-widget-domain-search.php
+++ b/tests/test-widget-domain-search.php
@@ -47,8 +47,10 @@ final class TestWidgetDomainSearch extends TestCase {
 
 		$widget->widget( $args, $instance );
 
-		// display domain search.
-		$this->expectOutputRegex( '/<div class="before_widget widget_search"><div class="rstore-domain-search" data-plid=12345 data-page_size="5" data-text_placeholder="Find your perfect domain name" data-text_search="Search" data-text_available="Congrats, your domain is available!" data-text_not_available="Sorry that domain is taken" data-text_cart="Continue to cart" data-text_select="Select" data-text_selected="Selected" data-text_verify="Verify">Domain Search<\/div><\/div>/' );
+		$this->assertRegExp(
+			'/<div class="before_widget widget_search"><div class="rstore-domain-search" data-plid=12345 data-page_size="5" data-text_placeholder="Find your perfect domain name" data-text_search="Search" data-text_available="Congrats, your domain is available!" data-text_not_available="Sorry that domain is taken" data-text_cart="Continue to cart" data-text_select="Select" data-text_selected="Selected" data-text_verify="Verify">Domain Search<\/div><\/div>/',
+			$widget->widget( $args, $instance )
+		);
 
 	}
 
@@ -78,9 +80,10 @@ final class TestWidgetDomainSearch extends TestCase {
 			'after_title'   => '</h3>',
 		];
 
-		$widget->widget( $args, $instance );
-
-		$this->expectOutputRegex( '/<div class="before_widget widget_search"><h3 class="widget-title">this is the title<\/h3><div class="rstore-domain-search" data-plid=12345/' );
+		$this->assertRegExp(
+			'/<div class="before_widget widget_search"><h3 class="widget-title">this is the title<\/h3><div class="rstore-domain-search" data-plid=12345/',
+			$widget->widget( $args, $instance )
+		);
 
 	}
 

--- a/tests/test-widget-login.php
+++ b/tests/test-widget-login.php
@@ -40,9 +40,11 @@ final class TestWidgetLogin extends TestCase {
 			'after_title'   => '</h3>',
 		];
 
-		$widget->widget( $args, $instance );
+		$this->assertRegExp(
+			'/<a class="logout-link" href="https:\/\/sso.secureserver.net\/logout\?plid=0&realm=idp&app=www" rel="nofollow">Log Out<\/a>/',
+			$widget->widget( $args, $instance )
+		);
 
-		$this->expectOutputRegex( '/<a class="logout-link" href="https:\/\/sso.secureserver.net\/logout\?plid=0&realm=idp&app=www" rel="nofollow">Log Out<\/a>/' );
 	}
 
 	/**
@@ -72,9 +74,10 @@ final class TestWidgetLogin extends TestCase {
 			'after_title'   => '</h3>',
 		];
 
-		$widget->widget( $args, $instance );
+		echo $widget->widget( $args, $instance );
 
 		$this->expectOutputRegex( '/<div class="before_widget login"><h3 class="widget-title">login<\/h3>/' );
+
 	}
 
 	/**

--- a/tests/test-widget-product.php
+++ b/tests/test-widget-product.php
@@ -41,7 +41,7 @@ final class TestWidgetProduct extends TestCase {
 			'after_title'   => '</h3>',
 		];
 
-		$widget->widget( $args, $instance );
+		echo $widget->widget( $args, $instance );
 
 		$this->expectOutputRegex( '/<button class="rstore-add-to-cart button" data-id="wordpress-basic" data-quantity="1" data-redirect="true">Add to cart<\/button>/' );
 
@@ -161,7 +161,7 @@ final class TestWidgetProduct extends TestCase {
 			'after_title'   => '</h3>',
 		];
 
-		$widget->widget( $args, $instance );
+		echo $widget->widget( $args, $instance );
 
 		// display main div tag.
 		$this->expectOutputRegex( '/<div class="before_widget product">/' );
@@ -195,7 +195,7 @@ final class TestWidgetProduct extends TestCase {
 
 				ob_start();
 
-				$widget->widget( $args, $instance );
+				echo $widget->widget( $args, $instance );
 
 				return ob_get_clean();
 


### PR DESCRIPTION
Resolves #48 

When `[rstore_product]` is wrapped in a `div` the shortcode renders outside of the `div` element.

When the product widget is used on a page or post using the `[rstore_product]` shortcode the shortcode is returned. When the Reseller Product widget is used, the widget gets echoed onto the page.

We may want to investigate the following shortcodes as well:
- ~`rstore_login`~ - contained in this PR
- ~`rstore_cart_button`~ - contained in this PR
- ~`rstore_domain_search`~ - contained in this PR