### PR TITLE
Fail softly on older PHP versions fixes #9

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -26,6 +26,7 @@ module.exports = function( grunt ) {
 						src: [
 							pkg.name + '.php',
 							'index.php',
+							'class-plugin.php',
 							'*.txt',
 							'assets/**',
 							'includes/**',

--- a/class-plugin.php
+++ b/class-plugin.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * GoDaddy Reseller Store plugin class.
+ *
+ * Main loader for the plugin
+ *
+ * @class    Reseller_Store/Permalinks
+ * @package  Reseller_Store/Plugin
+ * @category Class
+ * @author   GoDaddy
+ * @since    NEXT
+ */
+
+namespace Reseller_Store;
+
+if ( ! defined( 'ABSPATH' ) ) {
+
+	// @codeCoverageIgnoreStart
+	exit;
+	// @codeCoverageIgnoreEnd
+}
+
+final class Plugin {
+
+	use Singleton, Data, Helpers;
+
+	/**
+	 * Plugin version.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @var string
+	 */
+	const VERSION = '1.4.0';
+
+	/**
+	 * Plugin prefix.
+	 *
+	 * @since 0.2.0
+	 *
+	 * @var string
+	 */
+	const PREFIX = 'rstore_';
+
+	/**
+	 * Class contructor.
+	 *
+	 * @since 0.2.0
+	 */
+	private function __construct() {
+
+		$this->version    = self::VERSION;
+		$this->basename   = plugin_basename( __FILE__ );
+		$this->base_dir   = plugin_dir_path( __FILE__ );
+		$this->assets_url = plugin_dir_url( __FILE__ ) . 'assets/';
+		$this->api        = new API;
+
+		add_action(
+			'plugins_loaded', function () {
+
+				load_plugin_textdomain( 'reseller-store', false, dirname( $this->basename ) . '/languages' );
+
+			}
+		);
+
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+
+			WP_CLI::add_command( 'reseller', __NAMESPACE__ . '\CLI\Reseller' );
+
+			WP_CLI::add_command( 'reseller product', __NAMESPACE__ . '\CLI\Reseller_Product' );
+
+		}
+
+		new Restrictions;
+		new Post_Type;
+		new Taxonomy_Category;
+		new Taxonomy_Tag;
+
+		if ( ! rstore_is_setup() || ! rstore_has_products() ) {
+
+			new Setup;
+
+			return; // Bail until Setup is complete.
+
+		}
+
+		new Admin_Notices;
+		new ButterBean;
+		new Display;
+		new Embed;
+		new Permalinks;
+		new Sync;
+		new Widgets;
+		new Shortcodes;
+		new Bulk_Restore;
+
+	}
+
+}

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -17,8 +17,9 @@ use WP_Error;
 
 if ( ! defined( 'ABSPATH' ) ) {
 
+	// @codeCoverageIgnoreStart
 	exit;
-
+	// @codeCoverageIgnoreEnd
 }
 
 final class Setup {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
   "scripts": {
     "version": "grunt version && git add -A .",
     "postversion": "git push && git push --tags",
-    "lint": "eslint --ext .js ./assets/js/"
+    "lint": "eslint --ext .js ./assets/js/",
+    "build": "grunt build && mv build reseller-store && touch reseller-store.zip && rm reseller-store.zip && zip -r reseller-store.zip reseller-store && rm -rf reseller-store"
   },
   "dependencies": {
     "domain-search": "^2.1.2"

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,8 @@
 **Tags:**              [godaddy](https://wordpress.org/plugins/tags/godaddy/), [reseller](https://wordpress.org/plugins/tags/reseller/), [program](https://wordpress.org/plugins/tags/program/), [[store](https://wordpress.org/plugins/tags/store/)front](https://wordpress.org/plugins/tags/storefront/), store, [products](https://wordpress.org/plugins/tags/products/), [responsive](https://wordpress.org/plugins/tags/responsive/), [shortcode](https://wordpress.org/plugins/tags/shortcode/)  
 **Requires at least:** 4.6  
 **Tested up to:**      4.9  
-**Stable tag:**        1.3.0  
+**Requires PHP:**      5.4  
+**Stable tag:**        1.4.0  
 **License:**           GPL-2.0  
 **License URI:**       https://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,8 @@ Contributors:      godaddy, fjarrett, bfocht, eherman24
 Tags:              godaddy, reseller, program, storefront, store, products, responsive, shortcode
 Requires at least: 4.6
 Tested up to:      4.9
-Stable tag:        1.3.0
+Requires PHP:      5.4
+Stable tag:        1.4.0
 License:           GPL-2.0
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/reseller-store.php
+++ b/reseller-store.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: GoDaddy Reseller Store
  * Description: Sell hosting, domains, and more right from your WordPress site.
- * Version: 1.3.0
+ * Version: 1.4.0
  * Author: GoDaddy
  * Author URI: https://reseller.godaddy.com/
  * License: GPL-2.0
@@ -27,89 +27,36 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 }
 
-require_once __DIR__ . '/includes/autoload.php';
+if ( version_compare( phpversion(), '5.4.0', '<' ) ) {
 
-final class Plugin {
+	add_action(
+		'admin_notices', function() {
+		?>
+		<div class="update-nag">
+			<?php
+			echo sprintf(
+				/* translators: server PHP version */
+				esc_html__( 'You need to update your PHP version to run GoDaddy Reseller Store plugin. Required version 5.4 or higher. Your PHP version is: %s', 'reseller-store' ),
+				phpversion()
+			);
 
-	use Singleton, Data, Helpers;
-
-	/**
-	 * Plugin version.
-	 *
-	 * @since 0.2.0
-	 *
-	 * @var string
-	 */
-	const VERSION = '1.3.0';
-
-	/**
-	 * Plugin prefix.
-	 *
-	 * @since 0.2.0
-	 *
-	 * @var string
-	 */
-	const PREFIX = 'rstore_';
-
-	/**
-	 * Class contructor.
-	 *
-	 * @since 0.2.0
-	 */
-	private function __construct() {
-
-		$this->version    = self::VERSION;
-		$this->basename   = plugin_basename( __FILE__ );
-		$this->base_dir   = plugin_dir_path( __FILE__ );
-		$this->assets_url = plugin_dir_url( __FILE__ ) . 'assets/';
-		$this->api        = new API;
-
-		add_action( 'plugins_loaded', function () {
-
-			load_plugin_textdomain( 'reseller-store', false, dirname( $this->basename ) . '/languages' );
-
-		} );
-
-		if ( defined( 'WP_CLI' ) && WP_CLI ) {
-
-			WP_CLI::add_command( 'reseller', __NAMESPACE__ . '\CLI\Reseller' );
-
-			WP_CLI::add_command( 'reseller product', __NAMESPACE__ . '\CLI\Reseller_Product' );
-
+			?>
+		</div>
+		<?php
 		}
+	);
 
-		new Restrictions;
-		new Post_Type;
-		new Taxonomy_Category;
-		new Taxonomy_Tag;
+} else {
 
-		if ( ! rstore_is_setup() || ! rstore_has_products() ) {
+	require_once __DIR__ . '/includes/autoload.php';
+	require_once __DIR__ . '/class-plugin.php';
 
-			new Setup;
-
-			return; // Bail until Setup is complete.
-
-		}
-
-		new Admin_Notices;
-		new ButterBean;
-		new Display;
-		new Embed;
-		new Permalinks;
-		new Sync;
-		new Widgets;
-		new Shortcodes;
-		new Bulk_Restore;
-
-	}
-
+	rstore();
 }
-
-rstore();
 
 /**
  * Register deactivation hook.
  *
  * @since 0.2.0
  */
-register_deactivation_hook( __FILE__, [ __NAMESPACE__ . '\Setup', 'deactivate' ] );
+register_deactivation_hook( __FILE__, array( __NAMESPACE__ . '\Setup', 'deactivate' ) );

--- a/tests/test-plugin.php
+++ b/tests/test-plugin.php
@@ -26,4 +26,17 @@ final class TestPlugin extends TestCase {
 
 	}
 
+	/**
+	 * Test plugin loads and sets version.
+	 */
+	public function test_php_version() {
+
+		Plugin::reset();
+		$plugin = Plugin::load();
+		do_action( 'plugins_loaded' );
+
+		$this->assertGreaterThan( '1.0.0', $plugin->version );
+
+	}
+
 }

--- a/tests/test-setup.php
+++ b/tests/test-setup.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * GoDaddy Reseller Store test setup class
+ */
+
+namespace Reseller_Store;
+
+final class TestSetup extends TestCase {
+
+	/**
+	 * @testdox Test that Setup class exists.
+	 */
+	public function test_basics() {
+
+		$this->assertTrue( class_exists( __NAMESPACE__ . '\Setup' ) );
+
+	}
+
+	/**
+	 * @testdox Given the action admin_enqueue_scripts the styles and scripts should render
+	 */
+	public function test_admin_enqueue_scripts() {
+
+		$user_id = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+		wp_set_current_user( $user_id );
+		set_current_screen( 'admin.php?page=reseller-store-setup' );
+
+		$_SERVER['REQUEST_URI'] = 'admin.php?page=reseller-store-setup';
+
+		new Setup();
+
+		do_action( 'admin_enqueue_scripts' );
+
+		$this->assertTrue( wp_script_is( 'rstore-admin-permalinks' ), 'done' );
+
+	}
+
+}


### PR DESCRIPTION
Plugin will now display an admin notice if the PHP version < 5.4 

There were several user voice tickets and issues posted that were related to older versions of PHP.

<img width="942" alt="screen shot 2017-12-02 at 9 34 01 pm" src="https://user-images.githubusercontent.com/6027426/33522390-b7ea5e90-d7a8-11e7-9dc1-e3115a2ca385.png">
