### PR TITLE
add form to wp_kses_allowed_html and fix unit tests

### DIFF
--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -52,24 +52,31 @@ final class Blocks {
 
 		add_filter( 'block_categories', [ $this, 'block_categories' ], 10, 2 );
 
-		register_block_type(
-			'reseller-store/product',
-			array(
-				'render_callback' => [
-					$this,
-					'product',
-				],
-			)
-		);
+		add_action(
+			'init',
+			function() {
 
-		register_block_type(
-			'reseller-store/domain-search',
-			array(
-				'render_callback' => [
-					$this,
-					'domain_search',
-				],
-			)
+				register_block_type(
+					'reseller-store/product',
+					array(
+						'render_callback' => [
+							$this,
+							'product',
+						],
+					)
+				);
+
+				register_block_type(
+					'reseller-store/domain-search',
+					array(
+						'render_callback' => [
+							$this,
+							'domain_search',
+						],
+					)
+				);
+
+			}
 		);
 	}
 

--- a/includes/widgets/class-widget-base.php
+++ b/includes/widgets/class-widget-base.php
@@ -99,6 +99,13 @@ class Widget_Base extends \WP_Widget {
 			'data-*'      => true,
 		);
 
+		$allowed_html['form'] = array(
+			'role'   => true,
+			'method' => true,
+			'class'  => true,
+			'action' => true,
+		);
+
 		$data = array(
 			'data-id'                 => true,
 			'data-quantity'           => true,

--- a/tests/test-blocks.php
+++ b/tests/test-blocks.php
@@ -30,12 +30,12 @@ final class TestBlocks extends TestCase {
 
 		if ( function_exists( 'register_block_type' ) ) {
 
-			$this->assertTrue( wp_script_is( 'reseller-store-block-js' ), 'done' );
+			$this->assertTrue( wp_script_is( 'reseller-store-blocks-js' ), 'done' );
 			$this->assertTrue( wp_style_is( 'reseller-store-blocks-css' ), 'done' );
 
 		} else {
 
-			$this->assertFalse( wp_script_is( 'reseller-store-block-js' ), 'done' );
+			$this->assertFalse( wp_script_is( 'reseller-store-blocks-js' ), 'done' );
 			$this->assertFalse( wp_style_is( 'reseller-store-blocks-css' ), 'done' );
 
 		}
@@ -51,6 +51,7 @@ final class TestBlocks extends TestCase {
 
 		$blocks->enqueue_block_editor_assets();
 
+		$this->assertTrue( wp_script_is( 'reseller-store-blocks-js' ), 'done' );
 		$this->assertTrue( wp_style_is( 'reseller-store-blocks-css' ), 'done' );
 
 	}


### PR DESCRIPTION
Allow FORM tag in `wp_kses_allowed_html( 'post' );` because it was removed in the latest security release and we need it to perform a domain search.

https://make.wordpress.org/core/2018/12/13/backwards-compatibility-breaks-in-5-0-1/

Moved `register_block_type` to `init` action to fix broken unit tests.