### PR TITLE
WPBakery v6 fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ cache:
 language: php
 
 php:
-  - 5.4
+  - 5.6
   - 7.2
 
 branches:

--- a/includes/modules/rstore-vc-cart.php
+++ b/includes/modules/rstore-vc-cart.php
@@ -27,7 +27,7 @@ class VCCart extends \WPBakeryShortCode {
 	 * @since 1.6.0
 	 */
 	function __construct() {
-		add_action( 'init', array( $this, 'vc_mapping' ) );
+		$this->vc_mapping();
 	}
 
 	/**

--- a/includes/modules/rstore-vc-domain-search.php
+++ b/includes/modules/rstore-vc-domain-search.php
@@ -27,7 +27,7 @@ class VCDomainSearch extends \WPBakeryShortCode {
 	 * @since 1.6.0
 	 */
 	function __construct() {
-		add_action( 'init', array( $this, 'vc_mapping' ) );
+		$this->vc_mapping();
 	}
 
 	/**

--- a/includes/modules/rstore-vc-domain-simple.php
+++ b/includes/modules/rstore-vc-domain-simple.php
@@ -27,7 +27,7 @@ class VCDomainSimple extends \WPBakeryShortCode {
 	 * @since 1.6.0
 	 */
 	function __construct() {
-		add_action( 'init', array( $this, 'vc_mapping' ) );
+		$this->vc_mapping();
 	}
 
 	/**

--- a/includes/modules/rstore-vc-domain-transfer.php
+++ b/includes/modules/rstore-vc-domain-transfer.php
@@ -27,7 +27,7 @@ class VCDomainTransfer extends \WPBakeryShortCode {
 	 * @since 1.6.0
 	 */
 	function __construct() {
-		add_action( 'init', array( $this, 'vc_mapping' ) );
+		$this->vc_mapping();
 	}
 
 	/**

--- a/includes/modules/rstore-vc-login.php
+++ b/includes/modules/rstore-vc-login.php
@@ -27,7 +27,7 @@ class VCLogin extends \WPBakeryShortCode {
 	 * @since 1.6.0
 	 */
 	function __construct() {
-		add_action( 'init', array( $this, 'vc_mapping' ) );
+		$this->vc_mapping();
 	}
 
 	/**

--- a/includes/modules/rstore-vc-product.php
+++ b/includes/modules/rstore-vc-product.php
@@ -27,7 +27,7 @@ class VCProduct extends \WPBakeryShortCode {
 	 * @since 1.6.0
 	 */
 	function __construct() {
-		add_action( 'init', array( $this, 'vc_mapping' ) );
+		$this->vc_mapping();
 	}
 
 	/**

--- a/readme.md
+++ b/readme.md
@@ -102,6 +102,10 @@ While we recommend you use our widgets for your storefront, we do have a shortco
 You can add `?domainToCheck=example.com` to your query string on any page that has the domain search widget and the widget will perform an automatic search on page load.
 
 ## Changelog ##
+### 2.1.3 - July 2019 ###
+
+* Fix: Issue with WPBakery Page Builder v6
+
 ### 2.1.2 - February 2019 ###
 
 * Fix: Domain search theme compatibility fixes

--- a/readme.txt
+++ b/readme.txt
@@ -98,6 +98,10 @@ While we recommend you use our widgets for your storefront, we do have a shortco
 You can add `?domainToCheck=example.com` to your query string on any page that has the domain search widget and the widget will perform an automatic search on page load.
 
 == Changelog ==
+= 2.1.3 - July 2019 =
+
+* Fix: Issue with WPBakery Page Builder v6
+
 = 2.1.2 - February 2019 =
 
 * Fix: Domain search theme compatibility fixes


### PR DESCRIPTION
Fix the plugin so that short codes work with version 6 of WPBakery.  

Unit test issue ended up being WordPress now requiring PHP 5.6 as a minimum so I updated the travis build file accordingly.

 https://wordpress.org/news/2019/04/minimum-php-version-update/
