### PR TITLE
bump API sync from 15 mins to 4 hours

### DIFF
--- a/includes/class-sync.php
+++ b/includes/class-sync.php
@@ -30,7 +30,7 @@ final class Sync {
 	 *
 	 * @var int
 	 */
-	private $ttl = 900;
+	private $ttl = 14400; // 4 hours
 
 	/**
 	 * The time to wait in between API sync retries (in seconds).
@@ -39,7 +39,7 @@ final class Sync {
 	 *
 	 * @var int
 	 */
-	private $retry_ttl = 60;
+	private $retry_ttl = 120;
 
 	/**
 	 * Array of product properties that should be synced.
@@ -58,7 +58,7 @@ final class Sync {
 		/**
 		 * Filter the time to wait in between API syncs (in seconds).
 		 *
-		 * Default: 15 min
+		 * Default: 4 hours
 		 *
 		 * @since 0.2.0
 		 *
@@ -69,7 +69,7 @@ final class Sync {
 		/**
 		 * Filter the time to wait in between API sync retries (in seconds).
 		 *
-		 * Default: 1 min
+		 * Default: 2 mins
 		 *
 		 * Instead of using the normal TTL after a sync failure, this TTL will
 		 * be used so we can try again sooner. Set this value to something


### PR DESCRIPTION
After the release of version 2.2.5, the API sync began working properly again, but the 15 minute pricing refresh intervals were a bit aggressive and unnecessary due to the infrequent pricing updates. Bumping the refresh interval to 4 hours now.