### PR TITLE
feat: changes for php 8.1

### DIFF
--- a/includes/class-admin-notices.php
+++ b/includes/class-admin-notices.php
@@ -127,7 +127,7 @@ final class Admin_Notices {
 	 */
 	public static function dismiss_admin_notice() {
 
-		if ( false === wp_verify_nonce( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING ), self::nonce_key() ) ) {
+		if ( false === wp_verify_nonce( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ), self::nonce_key() ) ) {
 
 			$data = esc_html__( 'Sorry, you are not allowed to do that.', 'reseller-store' );
 

--- a/includes/class-blocks.php
+++ b/includes/class-blocks.php
@@ -50,7 +50,7 @@ final class Blocks {
 
 		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 
-		add_filter( 'block_categories', array( $this, 'block_categories' ), 10, 2 );
+		add_filter( 'block_categories_all', array( $this, 'block_categories' ), 10, 2 );
 
 		add_action(
 			'init',

--- a/includes/class-permalinks.php
+++ b/includes/class-permalinks.php
@@ -165,7 +165,7 @@ final class Permalinks {
 	private function save() {
 
 		if (
-			false === wp_verify_nonce( filter_input( INPUT_POST, '_wpnonce', FILTER_SANITIZE_STRING ), 'update-permalink' )
+			false === wp_verify_nonce( filter_input( INPUT_POST, '_wpnonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ), 'update-permalink' )
 			||
 			! isset( $_POST['permalink_structure'] ) // input var ok.
 		) {
@@ -179,12 +179,12 @@ final class Permalinks {
 		$old_permalinks = (array) rstore_get_option( 'permalinks', array() );
 		$new_permalinks = $old_permalinks;
 
-		$new_permalinks['category_base'] = sanitize_title( filter_input( INPUT_POST, 'rstore_category_base', FILTER_SANITIZE_STRING ) );
-		$new_permalinks['tag_base']      = sanitize_title( filter_input( INPUT_POST, 'rstore_tag_base', FILTER_SANITIZE_STRING ) );
-		$new_permalinks['product_base']  = sanitize_title( filter_input( INPUT_POST, 'rstore_product_base', FILTER_SANITIZE_STRING ) );
+		$new_permalinks['category_base'] = sanitize_title( filter_input( INPUT_POST, 'rstore_category_base', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$new_permalinks['tag_base']      = sanitize_title( filter_input( INPUT_POST, 'rstore_tag_base', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		$new_permalinks['product_base']  = sanitize_title( filter_input( INPUT_POST, 'rstore_product_base', FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
 
 		$old_structure = get_option( 'permalink_structure', '' );
-		$new_structure = filter_input( INPUT_POST, 'permalink_structure', FILTER_SANITIZE_STRING );
+		$new_structure = filter_input( INPUT_POST, 'permalink_structure', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 
 		if ( $new_permalinks === $old_permalinks && $old_structure === $new_structure ) {
 

--- a/includes/class-setup.php
+++ b/includes/class-setup.php
@@ -106,8 +106,8 @@ final class Setup {
 		/**
 		 * @todo Work on this logic
 		 */
-		$nonce = wp_verify_nonce( filter_input( INPUT_GET, 'nonce', FILTER_SANITIZE_STRING ), $install_nonce );
-		$plid  = filter_input( INPUT_GET, 'rstore_plid', FILTER_SANITIZE_STRING );
+		$nonce = wp_verify_nonce( filter_input( INPUT_GET, 'nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ), $install_nonce );
+		$plid  = filter_input( INPUT_GET, 'rstore_plid', FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 		$error = '';
 
 		if ( ! $nonce && $plid ) {
@@ -297,7 +297,7 @@ final class Setup {
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 
-			if ( false === wp_verify_nonce( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING ), self::install_nonce() ) ) {
+			if ( false === wp_verify_nonce( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ), self::install_nonce() ) ) {
 
 				return self::install_error(
 					'invalid_nonce',
@@ -352,7 +352,7 @@ final class Setup {
 
 		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
 
-			if ( false === wp_verify_nonce( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_STRING ), self::install_nonce() ) ) {
+			if ( false === wp_verify_nonce( filter_input( INPUT_POST, 'nonce', FILTER_SANITIZE_FULL_SPECIAL_CHARS ), self::install_nonce() ) ) {
 
 				return self::install_error(
 					'invalid_nonce',

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@
 **Contributors:** [godaddy](https://profiles.wordpress.org/godaddy), [fjarrett](https://profiles.wordpress.org/fjarrett), [bfocht](https://profiles.wordpress.org/bfocht), [eherman24](https://profiles.wordpress.org/eherman24)  
 **Tags:**              [reseller](https://wordpress.org/plugins/tags/reseller/), [program](https://wordpress.org/plugins/tags/program/), [storefront](https://wordpress.org/plugins/tags/storefront/), [products](https://wordpress.org/plugins/tags/products/), [posts](https://wordpress.org/plugins/tags/posts/), [shortcode](https://wordpress.org/plugins/tags/shortcode/), [ecommerce](https://wordpress.org/plugins/tags/ecommerce/), [blocks](https://wordpress.org/plugins/tags/blocks/)  
 **Requires at least:** 4.6  
-**Tested up to:**      6.0.1  
+**Tested up to:**      6.2.2  
 **Requires PHP:**      5.4  
 **Stable tag:**        2.2.7  
 **License:**           GPL-2.0  
@@ -102,6 +102,10 @@ While we recommend you use our widgets for your storefront, we do have a shortco
 You can add `?domainToCheck=example.com` to your query string on any page that has the domain search widget and the widget will perform an automatic search on page load.
 
 ## Changelog ##
+### 2.2.9 - May 2023 ### 
+
+* Update: Updates for PHP 8.1, tested with Wordpress 6.2.2
+
 ### 2.2.8 - April 2023 ### 
 
 * Update: Adding composer, removing duplicate asset includes

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors:      godaddy, fjarrett, bfocht, eherman24
 Tags:              reseller, program, storefront, products, posts, shortcode, ecommerce, blocks
 Requires at least: 4.6
-Tested up to:      6.0.1
+Tested up to:      6.2.2
 Requires PHP:      5.4
 Stable tag:        2.2.7
 License:           GPL-2.0
@@ -98,6 +98,10 @@ While we recommend you use our widgets for your storefront, we do have a shortco
 You can add `?domainToCheck=example.com` to your query string on any page that has the domain search widget and the widget will perform an automatic search on page load.
 
 == Changelog ==
+= 2.2.9 - May 2023 =
+
+* Update: Updates for PHP 8.1, tested with Wordpress 6.2.2
+
 = 2.2.8 - April 2023 =
 
 * Update: Adding composer, removing duplicate asset includes


### PR DESCRIPTION
FILTER_SANITIZE_STRING was deprecated in PHP 8.1
block_categories has been deprecated in wordpress 5.8, when block_categories_all was introduced.
In order to fully support PHP 8.2 (latest), we need to make a small change in the Butterbean package, which is external.