### PR TITLE
Use 2.2.15 tag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 **Requires at least:** 4.6  
 **Tested up to:**      6.5 
 **Requires PHP:**      5.4  
-**Stable tag:**        2.2.14  
+**Stable tag:**        2.2.15  
 **License:**           GPL-2.0  
 **License URI:**       https://www.gnu.org/licenses/gpl-2.0.html  
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags:              reseller, program, storefront, products, posts, shortcode, ec
 Requires at least: 4.6
 Tested up to:      6.5
 Requires PHP:      5.4
-Stable tag:        2.2.14
+Stable tag:        2.2.15
 License:           GPL-2.0
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/reseller-store.php
+++ b/reseller-store.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Reseller Store
  * Description: Sell hosting, domains, and more right from your WordPress site.
- * Version: 2.2.14
+ * Version: 2.2.15
  * Author: GoDaddy
  * Author URI: https://reseller.godaddy.com/
  * License: GPL-2.0


### PR DESCRIPTION
We incorrectly versioned this manually (did not run the `npm version` script in this repository). Manually adding the proper versions to readme.md, readme.txt, and reseller-store.php.

In the future - we just need to update the `version` in package.json and run `npm version`. 