### PR TITLE
fix: add failed image request handling in sideload_image function

### DIFF
--- a/includes/class-import.php
+++ b/includes/class-import.php
@@ -423,13 +423,14 @@ final class Import {
 
 		if ( ! function_exists( 'download_url' ) ) {
 
-			require_once ABSPATH . 'wp-admin/includes/file.php';
-
+		$tmp_file = download_url( $url );
+		if ( is_wp_error( $tmp_file ) ) {
+			return false;
 		}
 
 		$file_array = array(
 			'name'     => basename( $url ),
-			'tmp_name' => download_url( $url ),
+			'tmp_name' => $tmp_file,
 		);
 
 		if ( ! function_exists( 'media_handle_sideload' ) ) {


### PR DESCRIPTION
Gracefully handles sideloaded image download failures when capturing a reseller's product list.