### PR TITLE
Fix admin settings copy typos

### DIFF
--- a/includes/class-settings.php
+++ b/includes/class-settings.php
@@ -444,7 +444,7 @@ final class Settings {
 					'name'        => 'domain_page_size',
 					'label'       => esc_html__( 'Page size', 'reseller-store' ),
 					'type'        => 'number',
-					'description' => esc_html__( 'Override the number of results returned forß the advanced domain search.  Empty field means no override set.', 'reseller-store' ),
+					'description' => esc_html__( 'Override the number of results returned for the advanced domain search. Empty field means no override set.', 'reseller-store' ),
 				);
 
 				$settings[] = array(
@@ -777,7 +777,7 @@ final class Settings {
 		?>
 		<div class="card">
 			<h2 class="title"><?php esc_html_e( 'Check for new products', 'reseller-store' ); ?></h2>
-			<p><?php esc_html_e( 'Check API for new products. Note: This is will not update the content for any of your existing products that have been imported.', 'reseller-store' ); ?></p>
+			<p><?php esc_html_e( 'Check the API for new products. Note: This will not update the content for any of your existing products that have been imported.', 'reseller-store' ); ?></p>
 			<div class="wrap">
 				<form id='rstore-product-import'>
 					<input type="hidden" name="action" value="rstore_product_import">
@@ -805,8 +805,8 @@ final class Settings {
 				<td><label id="displayName" ></label><p class="description" id="tagline-description"><?php esc_html_e( 'Display name set in the Reseller Control Center', 'reseller-store' ); ?></p></td>
 			</tr>
 			<tr>
-				<th><label for="homeUrl"><?php esc_html_e( 'Home Url', 'reseller-store' ); ?></label></th>
-				<td><label id="homeUrl" ></label><p class="description" id="tagline-description"><?php esc_html_e( 'The home url is set in the Reseller Control Center should be set as your WordPress site.', 'reseller-store' ); ?></p></td>
+				<th><label for="homeUrl"><?php esc_html_e( 'Home URL', 'reseller-store' ); ?></label></th>
+				<td><label id="homeUrl" ></label><p class="description" id="tagline-description"><?php esc_html_e( 'The home URL in the Reseller Control Center should be set as your WordPress site.', 'reseller-store' ); ?></p></td>
 			</tr>
 			<tr>
 				<th><label for="customDomain"><?php esc_html_e( 'Storefront Domain', 'reseller-store' ); ?></label></th>

--- a/languages/reseller-store.pot
+++ b/languages/reseller-store.pot
@@ -331,8 +331,8 @@ msgstr ""
 
 #: includes/class-settings.php:451
 msgid ""
-"Override the number of results returned forß the advanced domain search.  "
-"Empty field means no override set."
+"Override the number of results returned for the advanced domain search. Empty "
+"field means no override set."
 msgstr ""
 
 #: includes/class-settings.php:456
@@ -555,7 +555,7 @@ msgstr ""
 
 #: includes/class-settings.php:778
 msgid ""
-"Check API for new products. Note: This is will not update the content for "
+"Check the API for new products. Note: This will not update the content for "
 "any of your existing products that have been imported."
 msgstr ""
 
@@ -572,13 +572,13 @@ msgid "Display name set in the Reseller Control Center"
 msgstr ""
 
 #: includes/class-settings.php:806
-msgid "Home Url"
+msgid "Home URL"
 msgstr ""
 
 #: includes/class-settings.php:807
 msgid ""
-"The home url is set in the Reseller Control Center should be set as your "
-"WordPress site."
+"The home URL in the Reseller Control Center should be set as your WordPress "
+"site."
 msgstr ""
 
 #: includes/class-settings.php:810


### PR DESCRIPTION
## Summary

This fixes a few small typos and wording issues in the Reseller Store admin settings copy.

## Changes

- Corrects the domain search page-size description.
- Fixes the "Check API for new products" note grammar.
- Updates "Home Url" to "Home URL" and clarifies the related description.
- Updates the POT template entries for the changed strings.

## Validation

- Ran `git diff --check` successfully.
- Checked the updated POT file with `msgfmt --check`; it only reports the existing standard POT header warnings.
