### PR TITLE
fix: escape data attributes in domain search widget to prevent XSS

### DIFF
--- a/includes/widgets/class-domain-search.php
+++ b/includes/widgets/class-domain-search.php
@@ -105,11 +105,11 @@ final class Domain_Search extends Widget_Base {
 			$classes .= ' rstore-domain-popup';
 		}
 
-		echo "<div class=\"$classes\" data-plid=\"$plid\"";
+		echo '<div class="' . esc_attr( $classes ) . '" data-plid="' . esc_attr( $plid ) . '"';
 
 		foreach ( $data as $key => $text ) {
 			if ( ! empty( $text ) ) {
-				echo ' data-' . $key . '="' . $text . '"';
+				echo ' data-' . esc_attr( $key ) . '="' . esc_attr( $text ) . '"';
 			}
 		}
 

--- a/tests/TestWidgetDomainSearch.php
+++ b/tests/TestWidgetDomainSearch.php
@@ -88,6 +88,39 @@ final class TestWidgetDomainSearch extends TestCase {
 	}
 
 	/**
+	 * @testdox Given instance text containing quotes the widget output should be escaped
+	 */
+	function test_widget_escapes_attribute_values() {
+
+		$widget = new Widgets\Domain_Search();
+		rstore_update_option( 'pl_id', 12345 );
+
+		$instance = array(
+			'title'         => '',
+			'placeholder'   => '',
+			'search'        => '',
+			'available'     => '',
+			'not_available' => '',
+			'cart'          => '" onmouseover="alert(1)',
+			'select'        => '',
+			'selected'      => '',
+		);
+
+		$args = array(
+			'before_widget' => '<div class="before_widget">',
+			'after_widget'  => '</div>',
+			'before_title'  => '<h3 class="widget-title">',
+			'after_title'   => '</h3>',
+		);
+
+		$output = $widget->widget( $args, $instance );
+
+		$this->assertStringNotContainsString( 'onmouseover="alert(1)"', $output );
+		$this->assertStringContainsString( 'data-text_cart="&quot; onmouseover=&quot;alert(1)"', $output );
+
+	}
+
+	/**
 	 * @testdox Given a new instance the instance should update
 	 */
 	function test_widget_update() {

--- a/tests/TestWidgetDomainSearch.php
+++ b/tests/TestWidgetDomainSearch.php
@@ -96,14 +96,14 @@ final class TestWidgetDomainSearch extends TestCase {
 		rstore_update_option( 'pl_id', 12345 );
 
 		$instance = array(
-			'title'         => '',
-			'placeholder'   => '',
-			'search'        => '',
-			'available'     => '',
-			'not_available' => '',
-			'cart'          => '" onmouseover="alert(1)',
-			'select'        => '',
-			'selected'      => '',
+			'title'              => '',
+			'text_placeholder'   => '',
+			'text_search'        => '',
+			'text_available'     => '',
+			'text_not_available' => '',
+			'text_cart'          => '" onmouseover="alert(1)',
+			'text_select'        => '',
+			'text_selected'      => '',
 		);
 
 		$args = array(


### PR DESCRIPTION
## Summary
- Escapes all values written into the domain search widget's `class`, `data-plid`, and `data-*` attributes with `esc_attr()`, closing a stored XSS vector where widget instance text (e.g. `text_cart`, `text_select`) was echoed into HTML attributes unescaped.
- Adds a regression test asserting that a payload containing a double quote is rendered safely instead of breaking out of the attribute.

## Details
Widget instance values are only sanitized with `wp_kses_post()` on save, which permits HTML but does not account for the values later being placed inside double-quoted attributes. A value containing an unescaped `"` could break out of the attribute and inject arbitrary markup/event handlers. `esc_attr()` is the correct escaping function for this context per WordPress security guidelines.

## Test plan
- [x] `php -l` on changed files
- [x] `phpcs` (project ruleset) on changed files
- [x] Added `test_widget_escapes_attribute_values` covering an attribute-breakout payload
- [ ] CI PHPUnit suite