### PR TITLE
chore: bump version to 3.0.1

### DIFF
--- a/.dev/src/blocks/domain-search/block.json
+++ b/.dev/src/blocks/domain-search/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "reseller-store/domain-search",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"title": "Domain Search",
 	"description": "A search form for domain registrations.",
 	"category": "reseller-store",

--- a/.dev/src/blocks/product/block.json
+++ b/.dev/src/blocks/product/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "reseller-store/product",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"title": "Product",
 	"description": "Display a product post",
 	"category": "reseller-store",

--- a/assets/blocks/domain-search/block.json
+++ b/assets/blocks/domain-search/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "reseller-store/domain-search",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"title": "Domain Search",
 	"description": "A search form for domain registrations.",
 	"category": "reseller-store",

--- a/assets/blocks/product/block.json
+++ b/assets/blocks/product/block.json
@@ -2,7 +2,7 @@
 	"$schema": "https://schemas.wp.org/trunk/block.json",
 	"apiVersion": 2,
 	"name": "reseller-store/product",
-	"version": "3.0.0",
+	"version": "3.0.1",
 	"title": "Product",
 	"description": "Display a product post",
 	"category": "reseller-store",

--- a/class-plugin.php
+++ b/class-plugin.php
@@ -35,7 +35,7 @@ final class Plugin {
 	 *
 	 * @var string
 	 */
-	const VERSION = '3.0.0';
+	const VERSION = '3.0.1';
 
 	/**
 	 * Plugin prefix.

--- a/includes/class-post-type.php
+++ b/includes/class-post-type.php
@@ -61,8 +61,6 @@ final class Post_Type {
 	 */
 	public function __construct() {
 
-		self::$default_permalink_base = sanitize_title( esc_html_x( 'products', 'slug name', 'reseller-store' ) );
-
 		add_action( 'init', array( $this, 'register' ) );
 		add_action( 'manage_posts_custom_column', array( $this, 'column_content' ), 10, 2 );
 		add_action( 'delete_post', array( $this, 'delete_imported_product' ) );
@@ -214,6 +212,8 @@ final class Post_Type {
 	 * @since  0.2.0
 	 */
 	public function register(): void {
+
+		self::$default_permalink_base = sanitize_title( esc_html_x( 'products', 'slug name', 'reseller-store' ) );
 
 		$labels = array(
 			'name'                  => esc_html_x( 'Products', 'post type general name', 'reseller-store' ),

--- a/includes/class-taxonomy-category.php
+++ b/includes/class-taxonomy-category.php
@@ -48,8 +48,6 @@ final class Taxonomy_Category {
 	 */
 	public function __construct() {
 
-		self::$default_permalink_base = sanitize_title( esc_html_x( 'product-category', 'slug name', 'reseller-store' ) );
-
 		add_action( 'init', array( $this, 'register' ) );
 	}
 
@@ -75,6 +73,8 @@ final class Taxonomy_Category {
 	 * @since  0.2.0
 	 */
 	public function register(): void {
+
+		self::$default_permalink_base = sanitize_title( esc_html_x( 'product-category', 'slug name', 'reseller-store' ) );
 
 		$labels = array(
 			'name'              => esc_html_x( 'Categories', 'taxonomy general name', 'reseller-store' ),

--- a/includes/class-taxonomy-tag.php
+++ b/includes/class-taxonomy-tag.php
@@ -48,8 +48,6 @@ final class Taxonomy_Tag {
 	 */
 	public function __construct() {
 
-		self::$default_permalink_base = sanitize_title( esc_html_x( 'product-tag', 'slug name', 'reseller-store' ) );
-
 		add_action( 'init', array( $this, 'register' ) );
 	}
 
@@ -75,6 +73,8 @@ final class Taxonomy_Tag {
 	 * @since  0.2.0
 	 */
 	public function register(): void {
+
+		self::$default_permalink_base = sanitize_title( esc_html_x( 'product-tag', 'slug name', 'reseller-store' ) );
 
 		$labels = array(
 			'name'              => esc_html_x( 'Tags', 'taxonomy general name', 'reseller-store' ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "reseller-store",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "reseller-store",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "license": "GPL-2.0",
             "dependencies": {
                 "domain-search": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "reseller-store",
     "title": "GoDaddy Reseller Store",
     "description": "Resell hosting, domains, and more right from your WordPress site.",
-    "version": "3.0.0",
+    "version": "3.0.1",
     "author": "GoDaddy",
     "license": "GPL-2.0",
     "repository": "godaddy/wp-reseller-store",

--- a/readme.md
+++ b/readme.md
@@ -109,6 +109,7 @@ You can add `?domainToCheck=example.com` to your query string on any page that h
 
 * Fix: Escape data attributes in domain search widget to prevent XSS
 * Fix: Cast button_new_tab to bool in Product widget to prevent fatal TypeError
+* Fix: Defer premature translation calls in post type and taxonomy registration to init to prevent Elementor editor breakage
 
 ### 3.0.0 - April 2026 ###
 

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@
 **Requires at least:** 6.2
 **Tested up to:**      6.8
 **Requires PHP:**      8.1
-**Stable tag:**        3.0.0
+**Stable tag:**        3.0.1
 **License:**           GPL-2.0  
 **License URI:**       https://www.gnu.org/licenses/gpl-2.0.html  
 
@@ -104,6 +104,11 @@ While we recommend you use our widgets for your storefront, we do have a shortco
 You can add `?domainToCheck=example.com` to your query string on any page that has the domain search widget and the widget will perform an automatic search on page load.
 
 ## Changelog ##
+
+### 3.0.1 - July 2026 ###
+
+* Fix: Escape data attributes in domain search widget to prevent XSS
+* Fix: Cast button_new_tab to bool in Product widget to prevent fatal TypeError
 
 ### 3.0.0 - April 2026 ###
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags:              reseller, program, storefront, products, posts, shortcode, ec
 Requires at least: 6.2
 Tested up to:      6.8
 Requires PHP:      8.1
-Stable tag:        3.0.0
+Stable tag:        3.0.1
 License:           GPL-2.0
 License URI:       https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -98,6 +98,11 @@ While we recommend you use our widgets for your storefront, we do have a shortco
 You can add `?domainToCheck=example.com` to your query string on any page that has the domain search widget and the widget will perform an automatic search on page load.
 
 == Changelog ==
+
+= 3.0.1 - July 2026 =
+
+* Fix: Escape data attributes in domain search widget to prevent XSS
+* Fix: Cast button_new_tab to bool in Product widget to prevent fatal TypeError
 
 = 3.0.0 - April 2026 =
 

--- a/readme.txt
+++ b/readme.txt
@@ -103,6 +103,7 @@ You can add `?domainToCheck=example.com` to your query string on any page that h
 
 * Fix: Escape data attributes in domain search widget to prevent XSS
 * Fix: Cast button_new_tab to bool in Product widget to prevent fatal TypeError
+* Fix: Defer premature translation calls in post type and taxonomy registration to init to prevent Elementor editor breakage
 
 = 3.0.0 - April 2026 =
 

--- a/reseller-store.php
+++ b/reseller-store.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: Reseller Store
  * Description: Sell hosting, domains, and more right from your WordPress site.
- * Version: 3.0.0
+ * Version: 3.0.1
  * Author: GoDaddy
  * Author URI: https://reseller.godaddy.com/
  * License: GPL-2.0


### PR DESCRIPTION
## Bump version to 3.0.1

Bump plugin version across all version-bearing files to 3.0.1 and update changelogs to publish the fixes from #201 and #202.

## Notable Items
- Fix: Escape data attributes in domain search widget to prevent XSS (#201)
- Fix: Cast button_new_tab to bool in Product widget to prevent fatal TypeError (#202)
- Fix: Defer premature `reseller-store` textdomain translation calls in `Post_Type`, `Taxonomy_Category`, and `Taxonomy_Tag` to the `init` hook
  - Each of these classes called `esc_html_x()` directly in its constructor, which runs synchronously at plugin-load time — before `init`, when `load_plugin_textdomain()` actually loads the `reseller-store` domain
  - This triggered WordPress's `_load_textdomain_just_in_time` notice (added in 6.7.0) on every request, and its HTML output was getting embedded into JSON responses, breaking `JSON.parse()` for callers relying on clean JSON (reproduced as a hard block on Elementor's editor — page creation/editing failed with `Unexpected token '<'... is not valid JSON`)
  - Moved the `self::$default_permalink_base` assignment (which calls `esc_html_x()`) out of each constructor and into the existing `register()` method, which is already hooked to `init`
- Updated `Stable tag` / `Version` in readme.txt, readme.md, reseller-store.php, class-plugin.php, package.json, package-lock.json